### PR TITLE
Fix icon now showing when used with cocoapods

### DIFF
--- a/Pod/Classes/FacebookMessengerActivity/M2DFacebookMessengerActivity.m
+++ b/Pod/Classes/FacebookMessengerActivity/M2DFacebookMessengerActivity.m
@@ -32,7 +32,16 @@
 
 - (UIImage *)activityImage
 {
-    return [UIImage imageNamed:@"FacebookMessenger.png"];
+  UIImage *image =  [UIImage imageNamed:@"FacebookMessenger.png"];
+  if (image==nil) {
+    NSBundle *bundle = [NSBundle bundleWithPath:[[NSBundle mainBundle]
+                                                 pathForResource:@"FacebookMessengerActivity"
+                                                 ofType:@"bundle"]];
+    image = [UIImage imageNamed:@"FacebookMessenger.png"
+                       inBundle:bundle
+  compatibleWithTraitCollection:nil];
+  }
+  return image;
 }
 
 - (NSString *)activityTitle


### PR DESCRIPTION
Because assets for this pod are bundled in `FacebookMessengerActivity.bundle` the icon is not shown. This commit fixes that.
